### PR TITLE
Add chat webserver with n8n webhook forwarding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+docker-compose.yml
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # testcodex
-testcodex
+
+This repository provides a simple chat web server that forwards messages to an n8n API webhook.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Set the `N8N_WEBHOOK_URL` environment variable to your n8n webhook.
+
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+Open `http://localhost:3000` in your browser to access the chat page.
+
+## Docker
+
+1. Build the image:
+   ```bash
+   docker build -t testcodex-chat .
+   ```
+2. Run the container, passing your webhook URL:
+   ```bash
+   docker run -p 3000:3000 -e N8N_WEBHOOK_URL=<your_webhook_url> testcodex-chat
+   ```
+
+Then open `http://localhost:3000` in your browser.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "testcodex-chat",
+  "version": "1.0.0",
+  "description": "Chat page forwarding messages to n8n",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "axios": "^1.5.0",
+    "express": "^4.18.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Chat with n8n</title>
+<style>
+body { font-family: Arial, sans-serif; padding: 20px; }
+#messages { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: scroll; }
+</style>
+</head>
+<body>
+<h1>Chat</h1>
+<div id="messages"></div>
+<input type="text" id="input" placeholder="Type a message" style="width:80%;">
+<button onclick="sendMessage()">Send</button>
+<script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,19 @@
+async function sendMessage() {
+    const input = document.getElementById('input');
+    const message = input.value.trim();
+    if (!message) return;
+    const res = await fetch('/message', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message })
+    });
+    const data = await res.json();
+    const messagesDiv = document.getElementById('messages');
+    const p = document.createElement('p');
+    p.textContent = 'You: ' + message;
+    messagesDiv.appendChild(p);
+    const resp = document.createElement('p');
+    resp.textContent = 'n8n: ' + (data.response || 'Error');
+    messagesDiv.appendChild(resp);
+    input.value = '';
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const axios = require('axios');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const N8N_WEBHOOK_URL = process.env.N8N_WEBHOOK_URL;
+
+if (!N8N_WEBHOOK_URL) {
+  console.warn('N8N_WEBHOOK_URL is not set. Messages will not be forwarded.');
+}
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.post('/message', async (req, res) => {
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ error: 'No message provided' });
+  }
+  if (!N8N_WEBHOOK_URL) {
+    return res.json({ response: 'n8n webhook not configured' });
+  }
+
+  try {
+    const response = await axios.post(N8N_WEBHOOK_URL, { message });
+    res.json({ response: response.data });
+  } catch (error) {
+    console.error('Error sending to n8n:', error.message);
+    res.status(500).json({ error: 'Failed to contact n8n' });
+  }
+});
+
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add Express server and simple HTML chat page
- forward posted messages to an n8n webhook
- document setup steps in README
- add Dockerfile and docker instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684030caf654833089aeb66350e0982d